### PR TITLE
Implement entity browsing feature with pagination and mention count

### DIFF
--- a/Agitprop.Core/Interfaces/IEntityRepository.cs
+++ b/Agitprop.Core/Interfaces/IEntityRepository.cs
@@ -13,5 +13,7 @@ namespace Agitprop.Core.Interfaces
         IEnumerable<Entity> SearchEntitiesAsync(string query);
         IEnumerable<Entity> GetEntitiesPaginatedAsync(DateOnly from, DateOnly to, int page, int pageSize);
         Task<IEnumerable<Entity>> GetAllEntitiesAsync(DateOnly from, DateOnly to);
+        (IEnumerable<(Entity Entity, int MentionCount)> Items, int TotalCount) GetEntitiesWithMentionCountAsync(
+            DateOnly from, DateOnly to, int page, int pageSize, string? search = null);
     }
 }

--- a/Agitprop.Sinks.Newsfeed/Database/EntityRepository.cs
+++ b/Agitprop.Sinks.Newsfeed/Database/EntityRepository.cs
@@ -239,6 +239,57 @@ public class EntityRepository : IEntityRepository
         }
     }
 
+    public (IEnumerable<(Entity Entity, int MentionCount)> Items, int TotalCount) GetEntitiesWithMentionCountAsync(
+        DateOnly from, DateOnly to, int page, int pageSize, string? search = null)
+    {
+        using var trace = _activitySource.StartActivity("GetEntitiesWithMentionCount", ActivityKind.Internal);
+        trace?.SetTag("from", from.ToString());
+        trace?.SetTag("to", to.ToString());
+        trace?.SetTag("page", page);
+        trace?.SetTag("pageSize", pageSize);
+        trace?.SetTag("search", search);
+
+        var fromUtc = DateTime.SpecifyKind(from.ToDateTime(TimeOnly.MinValue), DateTimeKind.Utc);
+        var toUtc = DateTime.SpecifyKind(to.ToDateTime(TimeOnly.MaxValue), DateTimeKind.Utc);
+
+        try
+        {
+            var baseQuery = _dbContext.Entities
+                .Where(e => e.Mentions.Any(m =>
+                    m.Article.PublishedTime >= fromUtc &&
+                    m.Article.PublishedTime <= toUtc));
+
+            if (!string.IsNullOrWhiteSpace(search))
+                baseQuery = baseQuery.Where(e => EF.Functions.ILike(e.Name, $"%{search}%"));
+
+            var totalCount = baseQuery.Count();
+
+            var items = baseQuery
+                .Select(e => new
+                {
+                    Entity = e,
+                    MentionCount = e.Mentions.Count(m =>
+                        m.Article.PublishedTime >= fromUtc &&
+                        m.Article.PublishedTime <= toUtc)
+                })
+                .OrderByDescending(x => x.MentionCount)
+                .ThenBy(x => x.Entity.Name)
+                .Skip((page - 1) * pageSize)
+                .Take(pageSize)
+                .AsNoTracking()
+                .ToList();
+
+            trace?.SetTag("totalCount", totalCount);
+            return (items.Select(x => (x.Entity.ToCoreModel(), x.MentionCount)), totalCount);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to retrieve entities with mention counts");
+            trace?.SetStatus(ActivityStatusCode.Error, ex.Message);
+            throw;
+        }
+    }
+
     public async Task<IEnumerable<Entity>> GetAllEntitiesAsync(DateOnly startDate, DateOnly endDate)
     {
         using var trace = _activitySource.StartActivity("GetAllEntities", ActivityKind.Internal);

--- a/Agitprop.Web.Api/Controllers/EntityController.cs
+++ b/Agitprop.Web.Api/Controllers/EntityController.cs
@@ -33,6 +33,58 @@ public class EntitiesController : ControllerBase
         _cache = cache;
     }
 
+    [HttpGet]
+    public ActionResult<EntityBrowseResponse> GetEntities(
+        [FromQuery] DateOnly from,
+        [FromQuery] DateOnly to,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 25,
+        [FromQuery] string? search = null)
+    {
+        using var activity = _activitySource.StartActivity("GetEntities", ActivityKind.Server);
+
+        if (from == default || to == default)
+            return BadRequest(new { error = "Both 'from' and 'to' query parameters are required." });
+
+        if (from > to)
+            return BadRequest(new { error = "The 'from' date must be earlier than or equal to the 'to' date." });
+
+        if (page < 1) page = 1;
+        if (pageSize < 1 || pageSize > 100) pageSize = 25;
+
+        var safeSearch = string.IsNullOrWhiteSpace(search) ? null : search.Trim();
+        var cacheKey = $"entities-browse:{from:yyyy-MM-dd}:{to:yyyy-MM-dd}:p{page}:ps{pageSize}:s{safeSearch}";
+        if (_cache.TryGetValue(cacheKey, out EntityBrowseResponse? cached) && cached is not null)
+            return Ok(cached);
+
+        try
+        {
+            var (items, totalCount) = _entityRepository.GetEntitiesWithMentionCountAsync(from, to, page, pageSize, safeSearch);
+
+            var response = new EntityBrowseResponse
+            {
+                TotalCount = totalCount,
+                Page = page,
+                PageSize = pageSize,
+                Items = items.Select(x => new EntityBrowseItem
+                {
+                    Id = x.Entity.Id ?? string.Empty,
+                    Name = x.Entity.Name,
+                    Type = x.Entity.Type ?? string.Empty,
+                    MentionCount = x.MentionCount
+                }).ToList()
+            };
+
+            _cache.Set(cacheKey, response, CacheDuration);
+            return Ok(response);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error browsing entities");
+            return StatusCode(500, new { error = "Failed to retrieve entities." });
+        }
+    }
+
     [HttpGet("{id}/domain-stats")]
     public ActionResult<EntityDomainStatsResponse> GetEntityDomainStats(
         string id,

--- a/Agitprop.Web.Api/DTOs/Responses/EntityBrowseResponse.cs
+++ b/Agitprop.Web.Api/DTOs/Responses/EntityBrowseResponse.cs
@@ -1,0 +1,17 @@
+namespace Agitprop.Web.Api.DTOs.Responses;
+
+public class EntityBrowseResponse
+{
+    public List<EntityBrowseItem> Items { get; set; } = [];
+    public int TotalCount { get; set; }
+    public int Page { get; set; }
+    public int PageSize { get; set; }
+}
+
+public class EntityBrowseItem
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string Type { get; set; } = string.Empty;
+    public int MentionCount { get; set; }
+}

--- a/Agitprop.Web.Client/Components/Layout/NavMenu.razor
+++ b/Agitprop.Web.Client/Components/Layout/NavMenu.razor
@@ -5,7 +5,12 @@
 
     <nav class="top-nav">
         <NavLink class="top-nav-item" href="/" Match="NavLinkMatch.All">
+            <span class="nav-icon bi-home-nav-menu"></span>
             <span class="nav-label">Home</span>
+        </NavLink>
+        <NavLink class="top-nav-item" href="/entities">
+            <span class="nav-icon bi-people-fill-nav-menu"></span>
+            <span class="nav-label">Entities</span>
         </NavLink>
     </nav>
 </div>

--- a/Agitprop.Web.Client/Components/Layout/NavMenu.razor.css
+++ b/Agitprop.Web.Client/Components/Layout/NavMenu.razor.css
@@ -88,6 +88,14 @@
     box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.22);
 }
 
+.bi-home-nav-menu {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill='white' d='M6.5 14.5v-3.505c0-.245.25-.495.5-.495h2c.25 0 .5.25.5.5v3.5a.5.5 0 0 0 .5.5h4a.5.5 0 0 0 .5-.5v-7a.5.5 0 0 0-.146-.354L13 5.793V2.5a.5.5 0 0 0-.5-.5h-1a.5.5 0 0 0-.5.5v1.293L8.354 1.146a.5.5 0 0 0-.708 0l-6 6A.5.5 0 0 0 1.5 7.5v7a.5.5 0 0 0 .5.5h4a.5.5 0 0 0 .5-.5z'/%3E%3C/svg%3E");
+}
+
+.bi-people-fill-nav-menu {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill='white' d='M7 14s-1 0-1-1 1-4 5-4 5 3 5 4-1 1-1 1H7zm4-6a3 3 0 1 0 0-6 3 3 0 0 0 0 6z'/%3E%3Cpath fill='white' fill-rule='evenodd' d='M5.216 14A2.238 2.238 0 0 1 5 13c0-1.355.68-2.75 1.936-3.72A6.325 6.325 0 0 0 5 9c-4 0-5 3-5 4s1 1 1 1h4.216z'/%3E%3Cpath fill='white' d='M4.5 8a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5z'/%3E%3C/svg%3E");
+}
+
 .bi-search-nav-menu {
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill='white' d='M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85zm-5.242 1.11a5 5 0 1 1 0-10 5 5 0 0 1 0 10z'/%3E%3C/svg%3E");
 }

--- a/Agitprop.Web.Client/Components/Pages/EntityBrowser.razor
+++ b/Agitprop.Web.Client/Components/Pages/EntityBrowser.razor
@@ -1,0 +1,213 @@
+@page "/entities"
+@rendermode InteractiveServer
+@using Agitprop.Web.Client.Models
+@inject Agitprop.Web.Client.Services.AnalyticsService Analytics
+@implements IDisposable
+
+<PageTitle>Entities</PageTitle>
+
+<div class="page-block entity-browser-page">
+    <section class="panel-card browser-header">
+        <div class="browser-title-row">
+            <div>
+                <h1 class="browser-title">Entities</h1>
+                <span class="browser-subtitle">Browse all monitored entities ranked by mention count</span>
+            </div>
+        </div>
+
+        <div class="browser-controls">
+            <div class="browser-search-wrap">
+                <input class="browser-search-input"
+                       type="search"
+                       placeholder="Search by name…"
+                       value="@SearchQuery"
+                       @oninput="OnSearchInput" />
+            </div>
+
+            <div class="timeframe-selector">
+                @for (var i = 0; i < TimeframeOptions.Count; i++)
+                {
+                    var option = TimeframeOptions[i];
+                    var idx = i;
+                    <button type="button"
+                            class="timeframe-pill @(SelectedTimeframeIndex == idx ? "active" : string.Empty)"
+                            disabled="@IsLoading"
+                            @onclick="() => ChangeTimeframe(idx)">
+                        @option.Label
+                    </button>
+                }
+            </div>
+        </div>
+    </section>
+
+    @if (!string.IsNullOrWhiteSpace(ErrorMessage))
+    {
+        <div class="alert alert-warning" role="alert">@ErrorMessage</div>
+    }
+
+    <section class="panel-card entity-list-panel">
+        @if (IsLoading && Items.Count == 0)
+        {
+            <div class="browser-loading">Loading…</div>
+        }
+        else if (Items.Count == 0)
+        {
+            <div class="browser-empty">No entities found for the selected timeframe@(string.IsNullOrWhiteSpace(SearchQuery) ? "." : " and search query.")</div>
+        }
+        else
+        {
+            <div class="browser-list-header">
+                <span class="browser-result-count">
+                    @TotalCount.ToString("N0") @(TotalCount == 1 ? "entity" : "entities")
+                    @if (!string.IsNullOrWhiteSpace(SearchQuery))
+                    {<text> matching "<strong>@SearchQuery</strong>"</text>}
+                </span>
+            </div>
+
+            <ul class="entity-browser-list">
+                @foreach (var item in Items)
+                {
+                    <li>
+                        <a href="/entity/@item.Id" class="entity-browser-row">
+                            <div class="entity-browser-left">
+                                <span class="entity-browser-name">@item.Name</span>
+                                @if (!string.IsNullOrWhiteSpace(item.Type))
+                                {
+                                    <span class="entity-type-badge">@item.Type</span>
+                                }
+                            </div>
+                            <span class="entity-browser-count">@item.MentionCount.ToString("N0") mentions</span>
+                        </a>
+                    </li>
+                }
+            </ul>
+
+            @if (TotalPages > 1)
+            {
+                <div class="browser-pagination">
+                    <button class="pagination-btn" @onclick="PrevPage" disabled="@(CurrentPage <= 1 || IsLoading)">← Prev</button>
+                    <span class="pagination-info">Page @CurrentPage of @TotalPages</span>
+                    <button class="pagination-btn" @onclick="NextPage" disabled="@(CurrentPage >= TotalPages || IsLoading)">Next →</button>
+                </div>
+            }
+        }
+    </section>
+</div>
+
+@code {
+    private const int PageSize = 25;
+
+    private static readonly List<TimeframeOption> TimeframeOptions = new()
+    {
+        new TimeframeOption("3 days", 3),
+        new TimeframeOption("7 days", 7),
+        new TimeframeOption("3 weeks", 21)
+    };
+
+    private List<EntityBrowseItem> Items { get; set; } = [];
+    private int TotalCount { get; set; }
+    private int CurrentPage { get; set; } = 1;
+    private int TotalPages => TotalCount == 0 ? 1 : (int)Math.Ceiling(TotalCount / (double)PageSize);
+
+    private int SelectedTimeframeIndex { get; set; } = 1; // default: 7 days
+    private TimeframeOption SelectedTimeframe => TimeframeOptions[SelectedTimeframeIndex];
+
+    private string SearchQuery { get; set; } = string.Empty;
+    private bool IsLoading { get; set; }
+    private string? ErrorMessage { get; set; }
+
+    private System.Threading.Timer? _debounceTimer;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        IsLoading = true;
+        ErrorMessage = null;
+        StateHasChanged();
+
+        try
+        {
+            var range = GetSelectedRange();
+            var result = await Analytics.GetEntitiesBrowseAsync(
+                range.From, range.To, CurrentPage, PageSize,
+                string.IsNullOrWhiteSpace(SearchQuery) ? null : SearchQuery.Trim());
+
+            if (result is not null)
+            {
+                Items = result.Items;
+                TotalCount = result.TotalCount;
+            }
+            else
+            {
+                Items = [];
+                TotalCount = 0;
+                ErrorMessage = "Unable to load entities.";
+            }
+        }
+        catch
+        {
+            ErrorMessage = "Unable to load entities.";
+            Items = [];
+            TotalCount = 0;
+        }
+        finally
+        {
+            IsLoading = false;
+        }
+    }
+
+    private void OnSearchInput(ChangeEventArgs e)
+    {
+        SearchQuery = e.Value?.ToString() ?? string.Empty;
+        _debounceTimer?.Dispose();
+        _debounceTimer = new System.Threading.Timer(async _ =>
+        {
+            CurrentPage = 1;
+            await InvokeAsync(async () =>
+            {
+                await LoadAsync();
+                StateHasChanged();
+            });
+        }, null, 350, System.Threading.Timeout.Infinite);
+    }
+
+    private async Task ChangeTimeframe(int idx)
+    {
+        if (SelectedTimeframeIndex == idx) return;
+        SelectedTimeframeIndex = idx;
+        CurrentPage = 1;
+        await LoadAsync();
+    }
+
+    private async Task PrevPage()
+    {
+        if (CurrentPage <= 1) return;
+        CurrentPage--;
+        await LoadAsync();
+    }
+
+    private async Task NextPage()
+    {
+        if (CurrentPage >= TotalPages) return;
+        CurrentPage++;
+        await LoadAsync();
+    }
+
+    private (DateOnly From, DateOnly To) GetSelectedRange()
+    {
+        var to = DateOnly.FromDateTime(DateTime.UtcNow);
+        var from = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-SelectedTimeframe.Days));
+        return (from, to);
+    }
+
+    public void Dispose()
+    {
+        _debounceTimer?.Dispose();
+    }
+
+    private sealed record TimeframeOption(string Label, int Days);
+}

--- a/Agitprop.Web.Client/Components/Pages/EntityBrowser.razor.css
+++ b/Agitprop.Web.Client/Components/Pages/EntityBrowser.razor.css
@@ -1,0 +1,182 @@
+.entity-browser-page {
+    max-width: 1120px;
+    margin: 0 auto;
+}
+
+/* Header card */
+.browser-header {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.browser-title-row {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+}
+
+.browser-title {
+    margin: 0;
+    font-size: clamp(1.5rem, 3vw, 2rem);
+    font-weight: 700;
+    color: #0f172a;
+}
+
+.browser-subtitle {
+    color: #64748b;
+    font-size: 0.95rem;
+    margin-top: 0.2rem;
+    display: block;
+}
+
+.browser-controls {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.browser-search-wrap {
+    flex: 1;
+    min-width: 200px;
+}
+
+.browser-search-input {
+    width: 100%;
+    padding: 0.55rem 1rem;
+    border: 1px solid #cbd5e1;
+    border-radius: 999px;
+    font-size: 0.95rem;
+    color: #0f172a;
+    background: #f8fafc;
+    outline: none;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.browser-search-input:focus {
+    border-color: #2563eb;
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.12);
+    background: #fff;
+}
+
+/* Entity list */
+.entity-list-panel {
+    padding: 0;
+    overflow: hidden;
+}
+
+.browser-list-header {
+    padding: 1rem 1.25rem 0.75rem;
+    border-bottom: 1px solid #e2e8f0;
+}
+
+.browser-result-count {
+    font-size: 0.9rem;
+    color: #64748b;
+}
+
+.entity-browser-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.entity-browser-list li + li {
+    border-top: 1px solid #f1f5f9;
+}
+
+.entity-browser-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.9rem 1.25rem;
+    text-decoration: none;
+    color: inherit;
+    transition: background 0.12s ease;
+}
+
+.entity-browser-row:hover {
+    background: #f8fafc;
+}
+
+.entity-browser-left {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    min-width: 0;
+    flex: 1;
+}
+
+.entity-browser-name {
+    font-weight: 600;
+    color: #0f172a;
+    font-size: 0.97rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.entity-browser-count {
+    font-size: 0.88rem;
+    color: #64748b;
+    white-space: nowrap;
+}
+
+/* Pagination */
+.browser-pagination {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 1rem;
+    padding: 1rem 1.25rem;
+    border-top: 1px solid #e2e8f0;
+}
+
+.pagination-btn {
+    padding: 0.5rem 1.25rem;
+    border-radius: 999px;
+    border: 1px solid #cbd5e1;
+    background: #fff;
+    color: #0f172a;
+    font-weight: 600;
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: all 0.12s ease;
+}
+
+.pagination-btn:hover:not(:disabled) {
+    background: #f1f5f9;
+    border-color: #94a3b8;
+}
+
+.pagination-btn:disabled {
+    opacity: 0.45;
+    cursor: not-allowed;
+}
+
+.pagination-info {
+    font-size: 0.9rem;
+    color: #475569;
+}
+
+/* States */
+.browser-loading,
+.browser-empty {
+    text-align: center;
+    padding: 3rem 1.25rem;
+    color: #64748b;
+    font-size: 0.95rem;
+}
+
+@media (max-width: 640px) {
+    .browser-controls {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .browser-search-wrap {
+        min-width: unset;
+    }
+}

--- a/Agitprop.Web.Client/Models/AnalyticsModels.cs
+++ b/Agitprop.Web.Client/Models/AnalyticsModels.cs
@@ -1,5 +1,21 @@
 namespace Agitprop.Web.Client.Models;
 
+public class EntityBrowseItem
+{
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string Type { get; set; } = string.Empty;
+    public int MentionCount { get; set; }
+}
+
+public class EntityBrowsePage
+{
+    public List<EntityBrowseItem> Items { get; set; } = [];
+    public int TotalCount { get; set; }
+    public int Page { get; set; }
+    public int PageSize { get; set; }
+}
+
 public class DomainStat
 {
     public string Domain { get; set; } = string.Empty;

--- a/Agitprop.Web.Client/Services/AnalyticsService.cs
+++ b/Agitprop.Web.Client/Services/AnalyticsService.cs
@@ -16,6 +16,30 @@ public class AnalyticsService
         _logger = logger;
     }
 
+    public async Task<EntityBrowsePage?> GetEntitiesBrowseAsync(DateOnly from, DateOnly to, int page, int pageSize, string? search)
+    {
+        var query = $"api/entities?from={ToQueryDate(from)}&to={ToQueryDate(to)}&page={page}&pageSize={pageSize}";
+        if (!string.IsNullOrWhiteSpace(search))
+            query += $"&search={Uri.EscapeDataString(search)}";
+
+        var response = await TryGetAsync<EntityBrowseResponseDto>(query);
+        if (response is null) return null;
+
+        return new EntityBrowsePage
+        {
+            TotalCount = response.TotalCount,
+            Page = response.Page,
+            PageSize = response.PageSize,
+            Items = response.Items.Select(i => new EntityBrowseItem
+            {
+                Id = i.Id,
+                Name = i.Name,
+                Type = i.Type,
+                MentionCount = i.MentionCount
+            }).ToList()
+        };
+    }
+
     public async Task<List<DomainStat>> GetEntityDomainStatsAsync(string entityId, DateOnly from, DateOnly to)
     {
         var endpoint = $"api/entities/{Uri.EscapeDataString(entityId)}/domain-stats?from={ToQueryDate(from)}&to={ToQueryDate(to)}";
@@ -132,6 +156,22 @@ public class AnalyticsService
     private static string ToQueryDate(DateOnly date)
     {
         return date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+    }
+
+    private sealed class EntityBrowseResponseDto
+    {
+        public List<EntityBrowseItemDto> Items { get; set; } = [];
+        public int TotalCount { get; set; }
+        public int Page { get; set; }
+        public int PageSize { get; set; }
+    }
+
+    private sealed class EntityBrowseItemDto
+    {
+        public string Id { get; set; } = string.Empty;
+        public string Name { get; set; } = string.Empty;
+        public string Type { get; set; } = string.Empty;
+        public int MentionCount { get; set; }
     }
 
     private sealed class EntityDomainStatsResponseDto


### PR DESCRIPTION
Introduce a new feature for browsing entities with pagination and mention counts. This includes updates to the API for fetching entities, enhancements to the client-side navigation, and the addition of necessary data models. The implementation supports efficient querying and response handling for entity data.